### PR TITLE
Docs/capabilities CAPABILITY_IAM to cfn deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ aws cloudformation deploy \
 aws cloudformation deploy \
   --template-file ./template.yaml \
   --stack-name ec2-image-builder-approver-notifications \
-  --parameter-overrides ApproverEmail=glennchi@amazon.com IAMPrincipalAssumeRoleARN=arn:aws:sts::123456789012:assumed-role/example/example TargetAccountEmail=example2@example.com TargetAccountIds=987654321012 LambdaCloudWatchLogGroupRetentionInDays=30 \
+  --parameter-overrides ApproverEmail=glennchi@amazon.com IAMPrincipalAssumeRoleARN=arn:aws:sts::123456789012:assumed-role/example/example TargetAccountEmail=example2@example.com TargetAccountIds=111122223333 LambdaCloudWatchLogGroupRetentionInDays=30 \
   --capabilities CAPABILITY_IAM
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ If you're using the AWS CLI, follow the instructions at [AWS CloudFormation docu
 aws cloudformation deploy \
   --template-file ./template.yaml \
   --stack-name ec2-image-builder-approver-notifications \
-  --parameter-overrides ApproverEmail=<REPLACE_WITH_EMAIL_ADDRESS> IAMPrincipalAssumeRoleARN=<REPLACE_WITH_IAM_PRINCIPAL_ARN> TargetAccountEmail=<REPLACE_WITH_EMAIL_ADDRESS> TargetAccountIds=<REPLACE_WITH_ACCOUNT_ID> LambdaCloudWatchLogGroupRetentionInDays=<REPLACE_WITH_VALID_DAYS>
+  --parameter-overrides ApproverEmail=<REPLACE_WITH_EMAIL_ADDRESS> IAMPrincipalAssumeRoleARN=<REPLACE_WITH_IAM_PRINCIPAL_ARN> TargetAccountEmail=<REPLACE_WITH_EMAIL_ADDRESS> TargetAccountIds=<REPLACE_WITH_ACCOUNT_ID> LambdaCloudWatchLogGroupRetentionInDays=<REPLACE_WITH_VALID_DAYS> \
+  --capabilities CAPABILITY_IAM
+  --
 # Example below where the IAMPrincipalAssumeRoleARN is the ARN belonging to an AWS IAM Identity Center (successor to AWS Single Sign-On) Federated User
 aws cloudformation deploy \
   --template-file ./template.yaml \
   --stack-name ec2-image-builder-approver-notifications \
-  --parameter-overrides ApproverEmail=example1@example.com IAMPrincipalAssumeRoleARN=arn:aws:sts::123456789012:assumed-role/example/example TargetAccountEmail=example2@example.com TargetAccountIds=987654321012 LambdaCloudWatchLogGroupRetentionInDays=30
+  --parameter-overrides ApproverEmail=glennchi@amazon.com IAMPrincipalAssumeRoleARN=arn:aws:sts::123456789012:assumed-role/example/example TargetAccountEmail=example2@example.com TargetAccountIds=987654321012 LambdaCloudWatchLogGroupRetentionInDays=30 \
+  --capabilities CAPABILITY_IAM
 ```
 
 After the stack is deployed, make sure to confirm the the SNS Topic Subscription Email sent to the `ApproverEmail` and `TargetAccountEmail` specified.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

CLI command requires `--capabilities CAPABILITY_IAM` to be passed since IAM roles are created. This pull request introduces that flag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
